### PR TITLE
feat: add token-based service access control

### DIFF
--- a/docs/2.guides/3.service-registry.md
+++ b/docs/2.guides/3.service-registry.md
@@ -3,7 +3,7 @@ title: Service Registry
 description: Type-safe service registration, retrieval, and guards
 author: zoobzio
 published: 2026-01-26
-updated: 2026-01-26
+updated: 2026-02-06
 tags:
   - service-registry
   - dependency-injection
@@ -129,6 +129,40 @@ func requireFeature(flag string) sum.Guard {
     }
 }
 ```
+
+### Token-Based Access Control
+
+Tokens are unforgeable capabilities that grant access to services. Create tokens at startup and distribute them to modules that need access.
+
+```go
+// Create tokens
+handlersToken := sum.NewToken("handlers")
+ingestToken := sum.NewToken("ingest")
+
+// Register with token requirements
+sum.Register[contracts.Users](k, usersStore).Guard(sum.Require(handlersToken))
+sum.Register[contracts.Jobs](k, jobsStore).Guard(sum.Require(handlersToken, ingestToken))
+```
+
+When multiple tokens are passed to `Require()`, any matching token grants access.
+
+**Using tokens:**
+
+```go
+// Inject token into context
+ctx := sum.WithToken(req.Context(), handlersToken)
+
+// Resolve service - succeeds if token matches
+users := sum.MustUse[contracts.Users](ctx)
+```
+
+**Why tokens?**
+
+- Prevent accidental cross-module dependencies
+- Make access grants explicit at registration
+- Catch violations at runtime rather than code review
+
+Services without `Require()` remain unrestricted for backwards compatibility.
 
 ## Service Enumeration
 

--- a/docs/4.reference/2.types.md
+++ b/docs/4.reference/2.types.md
@@ -3,7 +3,7 @@ title: Types Reference
 description: Type definitions and structures in sum
 author: zoobzio
 published: 2026-01-26
-updated: 2026-01-26
+updated: 2026-02-06
 tags:
   - reference
   - types
@@ -107,6 +107,38 @@ defer listener.Close()
 
 ---
 
+## Token
+
+```go
+type Token struct {
+    // contains filtered or unexported fields
+}
+```
+
+An unforgeable capability for service access control. Tokens are created with `NewToken()` and compared by internal ID.
+
+### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `String` | `() string` | Returns the token name for debugging |
+
+### Usage
+
+```go
+// Create tokens at startup
+handlersToken := sum.NewToken("handlers")
+
+// Require token for service access
+sum.Register[UserService](k, impl).Guard(sum.Require(handlersToken))
+
+// Inject token into context
+ctx := sum.WithToken(ctx, handlersToken)
+users := sum.MustUse[UserService](ctx)
+```
+
+---
+
 ## Re-exported Types
 
 These types are re-exported from slush for convenience:
@@ -175,9 +207,10 @@ Grants the capability to register services. Obtained from `Start()`.
 
 ```go
 var (
-    ErrNotFound     = slush.ErrNotFound
-    ErrAccessDenied = slush.ErrAccessDenied
-    ErrInvalidKey   = slush.ErrInvalidKey
+    ErrNotFound       = slush.ErrNotFound
+    ErrAccessDenied   = slush.ErrAccessDenied
+    ErrInvalidKey     = slush.ErrInvalidKey
+    ErrTokenRequired  = fmt.Errorf("token required")
 )
 ```
 
@@ -186,6 +219,7 @@ var (
 | `ErrNotFound` | `Use[T]()` called for unregistered type |
 | `ErrAccessDenied` | A guard denied access |
 | `ErrInvalidKey` | Invalid key passed to `Services()` |
+| `ErrTokenRequired` | `Require()` guard called without token in context |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.25.3
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/zoobzio/astql v1.0.5
 	github.com/zoobzio/capitan v1.0.0
@@ -18,7 +19,6 @@ require (
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/zoobzio/atom v1.0.0 // indirect
 	github.com/zoobzio/check v0.0.3 // indirect
 	github.com/zoobzio/dbml v1.0.0 // indirect

--- a/token.go
+++ b/token.go
@@ -1,0 +1,59 @@
+package sum
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Token is an unforgeable capability for service access.
+type Token struct {
+	id   string // random UUID, unexported
+	name string // for debugging/logging
+}
+
+// NewToken creates a new access token with the given name.
+func NewToken(name string) Token {
+	return Token{
+		id:   uuid.New().String(),
+		name: name,
+	}
+}
+
+// String returns the token name for debugging.
+func (t Token) String() string {
+	return t.name
+}
+
+type tokenKey struct{}
+
+// WithToken injects a token into the context.
+func WithToken(ctx context.Context, t Token) context.Context {
+	return context.WithValue(ctx, tokenKey{}, t)
+}
+
+func tokenFromContext(ctx context.Context) (Token, bool) {
+	t, ok := ctx.Value(tokenKey{}).(Token)
+	return t, ok
+}
+
+// ErrTokenRequired indicates a service requires a token but none was provided.
+var ErrTokenRequired = fmt.Errorf("token required")
+
+// Require returns a guard that checks for any of the provided tokens.
+// If the service has Require, the context must contain a matching token.
+func Require(tokens ...Token) Guard {
+	return func(ctx context.Context) error {
+		ctxToken, ok := tokenFromContext(ctx)
+		if !ok {
+			return ErrTokenRequired
+		}
+		for _, t := range tokens {
+			if t.id == ctxToken.id {
+				return nil
+			}
+		}
+		return fmt.Errorf("%w: token %q does not grant access", ErrAccessDenied, ctxToken.name)
+	}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,138 @@
+//go:build testing
+
+package sum
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewTokenUnique(t *testing.T) {
+	t1 := NewToken("test")
+	t2 := NewToken("test")
+
+	if t1.id == t2.id {
+		t.Error("expected different tokens to have different IDs")
+	}
+}
+
+func TestTokenString(t *testing.T) {
+	tok := NewToken("handlers")
+	if got := tok.String(); got != "handlers" {
+		t.Errorf("String() = %q, want %q", got, "handlers")
+	}
+}
+
+func TestWithTokenRoundTrip(t *testing.T) {
+	tok := NewToken("test")
+	ctx := WithToken(context.Background(), tok)
+
+	got, ok := tokenFromContext(ctx)
+	if !ok {
+		t.Fatal("expected token in context")
+	}
+	if got.id != tok.id {
+		t.Error("token IDs do not match")
+	}
+}
+
+func TestTokenFromContextMissing(t *testing.T) {
+	_, ok := tokenFromContext(context.Background())
+	if ok {
+		t.Error("expected no token in empty context")
+	}
+}
+
+func TestRequireAllowsMatchingToken(t *testing.T) {
+	tok := NewToken("handlers")
+	guard := Require(tok)
+
+	ctx := WithToken(context.Background(), tok)
+	if err := guard(ctx); err != nil {
+		t.Errorf("expected access granted, got %v", err)
+	}
+}
+
+func TestRequireDeniesWrongToken(t *testing.T) {
+	allowed := NewToken("handlers")
+	wrong := NewToken("ingest")
+	guard := Require(allowed)
+
+	ctx := WithToken(context.Background(), wrong)
+	err := guard(ctx)
+	if err == nil {
+		t.Fatal("expected access denied")
+	}
+	if !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("expected ErrAccessDenied, got %v", err)
+	}
+}
+
+func TestRequireDeniesNoToken(t *testing.T) {
+	tok := NewToken("handlers")
+	guard := Require(tok)
+
+	err := guard(context.Background())
+	if err == nil {
+		t.Fatal("expected error when no token provided")
+	}
+	if !errors.Is(err, ErrTokenRequired) {
+		t.Errorf("expected ErrTokenRequired, got %v", err)
+	}
+}
+
+func TestRequireMultipleTokensAnyGrantsAccess(t *testing.T) {
+	handlers := NewToken("handlers")
+	ingest := NewToken("ingest")
+	guard := Require(handlers, ingest)
+
+	// handlers token grants access
+	ctx := WithToken(context.Background(), handlers)
+	if err := guard(ctx); err != nil {
+		t.Errorf("handlers token should grant access: %v", err)
+	}
+
+	// ingest token also grants access
+	ctx = WithToken(context.Background(), ingest)
+	if err := guard(ctx); err != nil {
+		t.Errorf("ingest token should grant access: %v", err)
+	}
+
+	// unrelated token denied
+	other := NewToken("other")
+	ctx = WithToken(context.Background(), other)
+	if err := guard(ctx); err == nil {
+		t.Error("other token should be denied")
+	}
+}
+
+type testTokenSvc interface{ Op() }
+type testTokenSvcImpl struct{}
+
+func (testTokenSvcImpl) Op() {}
+
+func TestRequireIntegrationWithRegistry(t *testing.T) {
+	resetRegistry(t)
+
+	k := Start()
+	tok := NewToken("test")
+	Register[testTokenSvc](k, testTokenSvcImpl{}).Guard(Require(tok))
+	Freeze(k)
+
+	// Without token: denied
+	_, err := Use[testTokenSvc](context.Background())
+	if err == nil {
+		t.Error("expected error without token")
+	}
+
+	// With token: allowed
+	ctx := WithToken(context.Background(), tok)
+	svc, err := Use[testTokenSvc](ctx)
+	if err != nil {
+		t.Fatalf("expected access with token, got %v", err)
+	}
+	if svc == nil {
+		t.Error("expected non-nil service")
+	}
+}


### PR DESCRIPTION
  Implements capability-based access control for service resolution.
  Services can declare required tokens at registration via Require(),
  and callers must inject matching tokens into context via WithToken().

  Closes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced token-based access control for service registration and runtime validation
  * Support for multi-token authorization allowing any matching token to grant access
  * Token injection into service context for seamless resolution

* **Documentation**
  * Updated service registry guide with token-based access control section
  * Added token type and token-required error to reference documentation

* **Chores**
  * Updated UUID dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->