### PR TITLE
feat: add For() method as simplified token guard

### DIFF
--- a/docs/2.guides/3.service-registry.md
+++ b/docs/2.guides/3.service-registry.md
@@ -140,11 +140,13 @@ handlersToken := sum.NewToken("handlers")
 ingestToken := sum.NewToken("ingest")
 
 // Register with token requirements
-sum.Register[contracts.Users](k, usersStore).Guard(sum.Require(handlersToken))
-sum.Register[contracts.Jobs](k, jobsStore).Guard(sum.Require(handlersToken, ingestToken))
+sum.Register[contracts.Users](k, usersStore).For(handlersToken)
+sum.Register[contracts.Jobs](k, jobsStore).For(handlersToken, ingestToken)
 ```
 
-When multiple tokens are passed to `Require()`, any matching token grants access.
+When multiple tokens are passed to `For()`, any matching token grants access.
+
+The `For()` method is equivalent to `Guard(sum.Require(tokens...))` but reads more naturally for the common case.
 
 **Using tokens:**
 

--- a/docs/4.reference/2.types.md
+++ b/docs/4.reference/2.types.md
@@ -159,21 +159,32 @@ A validation function that permits or denies service access.
 ### Handle
 
 ```go
-type Handle[T any] = slush.Handle[T]
+type Handle[T any] struct {
+    *slush.Handle[T]
+}
 ```
 
-Configures a registered service with optional guards.
+Configures a registered service with optional guards. Wraps `slush.Handle` to provide sum-specific conveniences.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `Guard` | `(guards ...Guard) *Handle[T]` | Attaches guards to the service |
+| `Guard` | `(g Guard) *Handle[T]` | Attaches a custom guard to the service |
+| `For` | `(tokens ...Token) *Handle[T]` | Restricts access to contexts bearing any of the provided tokens |
 
 **Usage:**
 
 ```go
+// Token-based access (common case)
+sum.Register[UserService](k, impl).For(handlersToken)
+sum.Register[JobService](k, impl).For(handlersToken, ingestToken)
+
+// Custom guard logic
 sum.Register[AdminService](k, impl).
     Guard(requireRole("admin")).
     Guard(requireTenant)
+
+// Mixed
+sum.Register[AuditService](k, impl).Guard(requireTenant).For(adminToken)
 ```
 
 ---


### PR DESCRIPTION
  Handle[T] is now a wrapper struct embedding *slush.Handle[T] rather
  than a type alias. This allows sum to extend the slush API with
  token-specific conveniences while preserving access to underlying
  methods.

  New API:
    sum.Register[Users](k, store).For(handlersToken)
    sum.Register[Jobs](k, store).For(handlersToken, ingestToken)

  Equivalent to Guard(Require(tokens...)) but more concise for the
  common case of token-based access control.

  Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added For() method to enable token-based access control for registered services.

* **Updates**
  * Modified Guard method to accept a single guard parameter.
  * Updated documentation examples to demonstrate the new For() token-based access pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->