### PR TITLE
feat: make NewDatabase and NewSearch infallible

### DIFF
--- a/data.go
+++ b/data.go
@@ -31,12 +31,13 @@ type Store[M any] struct {
 
 // NewStore creates a Store[M] and registers it with the scio catalog.
 // Requires sum.New() to have been called first.
-func NewStore[M any](provider grub.StoreProvider, name string) (*Store[M], error) {
+// Panics if catalog registration fails (duplicate store name is a programmer error).
+func NewStore[M any](provider grub.StoreProvider, name string) *Store[M] {
 	store := grub.NewStore[M](provider)
 	if err := svc().catalog.RegisterStore("kv://"+name, store.Atomic()); err != nil {
-		return nil, err
+		panic("sum: NewStore: " + err.Error())
 	}
-	return &Store[M]{Store: store}, nil
+	return &Store[M]{Store: store}
 }
 
 // Bucket wraps grub.Bucket and registers with scio on creation.
@@ -47,12 +48,13 @@ type Bucket[M any] struct {
 
 // NewBucket creates a Bucket[M] and registers it with the scio catalog.
 // Requires sum.New() to have been called first.
-func NewBucket[M any](provider grub.BucketProvider, name string) (*Bucket[M], error) {
+// Panics if catalog registration fails (duplicate bucket name is a programmer error).
+func NewBucket[M any](provider grub.BucketProvider, name string) *Bucket[M] {
 	bucket := grub.NewBucket[M](provider)
 	if err := svc().catalog.RegisterBucket("bcs://"+name, bucket.Atomic()); err != nil {
-		return nil, err
+		panic("sum: NewBucket: " + err.Error())
 	}
-	return &Bucket[M]{Bucket: bucket}, nil
+	return &Bucket[M]{Bucket: bucket}
 }
 
 // Search wraps grub.Search and registers with scio on creation.

--- a/data.go
+++ b/data.go
@@ -14,15 +14,13 @@ type Database[M any] struct {
 
 // NewDatabase creates a Database[M] and registers it with the scio catalog.
 // Requires sum.New() to have been called first.
-func NewDatabase[M any](db *sqlx.DB, table string, renderer astql.Renderer) (*Database[M], error) {
-	gdb, err := grub.NewDatabase[M](db, table, renderer)
-	if err != nil {
-		return nil, err
-	}
+// Panics if catalog registration fails (duplicate table name is a programmer error).
+func NewDatabase[M any](db *sqlx.DB, table string, renderer astql.Renderer) *Database[M] {
+	gdb := grub.NewDatabase[M](db, table, renderer)
 	if err := svc().catalog.RegisterDatabase("db://"+table, gdb.Atomic()); err != nil {
-		return nil, err
+		panic("sum: NewDatabase: " + err.Error())
 	}
-	return &Database[M]{Database: gdb}, nil
+	return &Database[M]{Database: gdb}
 }
 
 // Store wraps grub.Store and registers with scio on creation.
@@ -65,13 +63,11 @@ type Search[M any] struct {
 
 // NewSearch creates a Search[M] and registers it with the scio catalog.
 // Requires sum.New() to have been called first.
-func NewSearch[M any](provider grub.SearchProvider, index string) (*Search[M], error) {
-	search, err := grub.NewSearch[M](provider, index)
-	if err != nil {
-		return nil, err
-	}
+// Panics if catalog registration fails (duplicate index name is a programmer error).
+func NewSearch[M any](provider grub.SearchProvider, index string) *Search[M] {
+	search := grub.NewSearch[M](provider, index)
 	if err := svc().catalog.RegisterSearch("srch://"+index, search.Atomic()); err != nil {
-		return nil, err
+		panic("sum: NewSearch: " + err.Error())
 	}
-	return &Search[M]{Search: search}, nil
+	return &Search[M]{Search: search}
 }

--- a/docs/1.learn/2.quickstart.md
+++ b/docs/1.learn/2.quickstart.md
@@ -137,7 +137,7 @@ Wire databases to the data catalog:
 
 ```go
 // Create database wrapper (auto-registers with catalog)
-database, err := sum.NewDatabase[User](
+database := sum.NewDatabase[User](
     db,              // *sqlx.DB
     "users",         // table name
     renderer,        // astql.Renderer

--- a/docs/1.learn/3.concepts.md
+++ b/docs/1.learn/3.concepts.md
@@ -98,7 +98,7 @@ Data wrappers provide typed access to persistence with automatic catalog registr
 **How to think about it:** Data wrappers are thin layers over grub stores with automatic catalog registration. Embed them in your own types to add domain-specific methods.
 
 ```go
-database, err := sum.NewDatabase[User](db, "users", renderer)
+database := sum.NewDatabase[User](db, "users", renderer)
 
 type UserRepo struct {
     *sum.Database[User]

--- a/docs/1.learn/4.architecture.md
+++ b/docs/1.learn/4.architecture.md
@@ -124,18 +124,15 @@ Each data helper follows the same pattern:
 
 ```go
 func Database[C, M any](k Key, db *sqlx.DB, table, keyCol string,
-    renderer astql.Renderer, factory func(*grub.Database[M]) C) error {
+    renderer astql.Renderer, factory func(*grub.Database[M]) C) {
 
-    gdb, err := grub.NewDatabase[M](db, table, keyCol, renderer)
-    if err != nil {
-        return err
-    }
+    gdb := grub.NewDatabase[M](db, table, keyCol, renderer)
 
     impl := factory(gdb)
     Register[C](k, impl)
 
     s := svc()
-    return s.catalog.RegisterDatabase("db://"+table, gdb.Atomic())
+    s.catalog.RegisterDatabase("db://"+table, gdb.Atomic())
 }
 ```
 

--- a/docs/2.guides/1.testing.md
+++ b/docs/2.guides/1.testing.md
@@ -150,10 +150,7 @@ func TestUserRepository_Integration(t *testing.T) {
     db := setupTestDB(t)
     _ = sum.Start()
 
-    database, err := sum.NewDatabase[User](db, "users", renderer)
-    if err != nil {
-        t.Fatalf("failed to create database: %v", err)
-    }
+    database := sum.NewDatabase[User](db, "users", renderer)
 
     // Create repository with embedded database
     type UserRepository struct {

--- a/docs/2.guides/2.troubleshooting.md
+++ b/docs/2.guides/2.troubleshooting.md
@@ -209,7 +209,7 @@ if err := db.Ping(); err != nil {
 }
 
 // Then create
-database, err := sum.NewDatabase[Model](db, "table", renderer)
+database := sum.NewDatabase[Model](db, "table", renderer)
 ```
 
 ### "service not started" on Shutdown

--- a/docs/2.guides/5.data-stores.md
+++ b/docs/2.guides/5.data-stores.md
@@ -24,7 +24,7 @@ All data helpers follow the same pattern:
 4. Embed the wrapper in your own struct to add custom methods
 
 ```go
-db, err := sum.NewDatabase[Model](connection, table, renderer)
+db := sum.NewDatabase[Model](connection, table, renderer)
 ```
 
 The type parameter:
@@ -52,14 +52,11 @@ func (r *UserRepository) FindByEmail(ctx context.Context, email string) (*User, 
 }
 
 // Create and register
-database, err := sum.NewDatabase[User](
+database := sum.NewDatabase[User](
     sqlxDB,             // *sqlx.DB connection
     "users",            // table name
     astqlRenderer,      // SQL renderer
 )
-if err != nil {
-    return err
-}
 
 userRepo := &UserRepository{Database: database}
 ```
@@ -89,13 +86,10 @@ func (s *SessionStore) GetByToken(ctx context.Context, token string) (*Session, 
 }
 
 // Create and register
-store, err := sum.NewStore[Session](
+store := sum.NewStore[Session](
     kvProvider,         // grub.StoreProvider (Redis, etc.)
     "sessions",         // store name
 )
-if err != nil {
-    return err
-}
 
 sessionStore := &SessionStore{Store: store}
 ```
@@ -123,13 +117,10 @@ func (d *DocumentStore) GetDocument(ctx context.Context, id string) (*Document, 
 }
 
 // Create and register
-bucket, err := sum.NewBucket[Document](
+bucket := sum.NewBucket[Document](
     bucketProvider,     // grub.BucketProvider (S3, GCS, etc.)
     "documents",        // bucket name
 )
-if err != nil {
-    return err
-}
 
 docStore := &DocumentStore{Bucket: bucket}
 ```
@@ -173,28 +164,17 @@ The catalog enables:
 
 ## Error Handling
 
-All data helpers return errors from store creation or catalog registration:
+Data helpers are infallible constructors that panic on programmer error (e.g., nil connection, uninitialized service). Ensure the `Service` singleton is created via `sum.New()` before calling any data helper:
 
 ```go
-database, err := sum.NewDatabase[Model](db, table, renderer)
-if err != nil {
-    log.Fatalf("failed to create database: %v", err)
-}
-
-store, err := sum.NewStore[Model](provider, "name")
-if err != nil {
-    log.Fatalf("failed to create store: %v", err)
-}
-
-bucket, err := sum.NewBucket[Model](provider, "name")
-if err != nil {
-    log.Fatalf("failed to create bucket: %v", err)
-}
+database := sum.NewDatabase[Model](db, table, renderer)
+store := sum.NewStore[Model](provider, "name")
+bucket := sum.NewBucket[Model](provider, "name")
 ```
 
-Common errors:
-- Invalid database connection
-- Table doesn't exist
+Common panics:
+- Service not initialized (call `sum.New()` first)
+- Nil database connection or provider
 - Catalog registration failure (e.g., duplicate name)
 
 ## Best Practices

--- a/docs/3.integrations/2.grub.md
+++ b/docs/3.integrations/2.grub.md
@@ -52,7 +52,7 @@ type User struct {
 }
 
 // Create wrapper (registers with catalog)
-database, err := sum.NewDatabase[User](
+database := sum.NewDatabase[User](
     db,           // *sqlx.DB
     "users",      // table name
     renderer,     // astql.Renderer for your dialect
@@ -74,13 +74,10 @@ For key-value stores:
 
 ```go
 // Create wrapper (registers with catalog)
-store, err := sum.NewStore[Session](
+store := sum.NewStore[Session](
     provider,     // grub.StoreProvider
     "sessions",   // store name
 )
-if err != nil {
-    return err
-}
 
 // Embed in your own type for custom methods
 type SessionStore struct {
@@ -98,13 +95,10 @@ For object storage:
 
 ```go
 // Create wrapper (registers with catalog)
-bucket, err := sum.NewBucket[Document](
+bucket := sum.NewBucket[Document](
     provider,     // grub.BucketProvider
     "documents",  // bucket name
 )
-if err != nil {
-    return err
-}
 
 // Embed in your own type for custom methods
 type DocumentStore struct {

--- a/docs/3.integrations/5.scio.md
+++ b/docs/3.integrations/5.scio.md
@@ -44,7 +44,7 @@ Data helpers automatically register with this catalog:
 When you use a data wrapper, it registers with the catalog:
 
 ```go
-database, err := sum.NewDatabase[User](db, "users", renderer)
+database := sum.NewDatabase[User](db, "users", renderer)
 // Catalog now has: db://users
 ```
 

--- a/docs/4.reference/1.api.md
+++ b/docs/4.reference/1.api.md
@@ -242,7 +242,7 @@ cfg := sum.MustUse[AppConfig](ctx)
 ### NewDatabase
 
 ```go
-func NewDatabase[M any](db *sqlx.DB, table string, renderer astql.Renderer) (*Database[M], error)
+func NewDatabase[M any](db *sqlx.DB, table string, renderer astql.Renderer) *Database[M]
 ```
 
 Creates a database wrapper and registers with the data catalog.
@@ -255,9 +255,9 @@ Creates a database wrapper and registers with the data catalog.
 - `table` — The table name
 - `renderer` — SQL renderer for the database dialect
 
-**Returns:**
-- `*Database[M]` — Wrapper embedding `*grub.Database[M]`
-- Error if store creation fails
+**Returns:** `*Database[M]` — Wrapper embedding `*grub.Database[M]`.
+
+**Panics:** If the Service singleton has not been created via `New()`, or on invalid arguments.
 
 **Behavior:**
 1. Creates `grub.Database[M]`
@@ -267,10 +267,7 @@ Creates a database wrapper and registers with the data catalog.
 **Example:**
 
 ```go
-database, err := sum.NewDatabase[User](db, "users", renderer)
-if err != nil {
-    return err
-}
+database := sum.NewDatabase[User](db, "users", renderer)
 
 // Embed in your own type
 type UserRepo struct {
@@ -286,7 +283,7 @@ See also: [Types Reference](2.types.md#grub-types)
 ### NewStore
 
 ```go
-func NewStore[M any](provider grub.StoreProvider, name string) (*Store[M], error)
+func NewStore[M any](provider grub.StoreProvider, name string) *Store[M]
 ```
 
 Creates a key-value store wrapper and registers with the data catalog.
@@ -298,9 +295,9 @@ Creates a key-value store wrapper and registers with the data catalog.
 - `provider` — The KV store provider
 - `name` — The store name
 
-**Returns:**
-- `*Store[M]` — Wrapper embedding `*grub.Store[M]`
-- Error if catalog registration fails
+**Returns:** `*Store[M]` — Wrapper embedding `*grub.Store[M]`.
+
+**Panics:** If the Service singleton has not been created via `New()`, or on invalid arguments.
 
 **Behavior:**
 1. Creates `grub.Store[M]`
@@ -310,10 +307,7 @@ Creates a key-value store wrapper and registers with the data catalog.
 **Example:**
 
 ```go
-store, err := sum.NewStore[Session](provider, "sessions")
-if err != nil {
-    return err
-}
+store := sum.NewStore[Session](provider, "sessions")
 
 // Embed in your own type
 type SessionStore struct {
@@ -327,7 +321,7 @@ sessionStore := &SessionStore{Store: store}
 ### NewBucket
 
 ```go
-func NewBucket[M any](provider grub.BucketProvider, name string) (*Bucket[M], error)
+func NewBucket[M any](provider grub.BucketProvider, name string) *Bucket[M]
 ```
 
 Creates an object storage bucket wrapper and registers with the data catalog.
@@ -339,9 +333,9 @@ Creates an object storage bucket wrapper and registers with the data catalog.
 - `provider` — The bucket provider
 - `name` — The bucket name
 
-**Returns:**
-- `*Bucket[M]` — Wrapper embedding `*grub.Bucket[M]`
-- Error if catalog registration fails
+**Returns:** `*Bucket[M]` — Wrapper embedding `*grub.Bucket[M]`.
+
+**Panics:** If the Service singleton has not been created via `New()`, or on invalid arguments.
 
 **Behavior:**
 1. Creates `grub.Bucket[M]`
@@ -351,10 +345,7 @@ Creates an object storage bucket wrapper and registers with the data catalog.
 **Example:**
 
 ```go
-bucket, err := sum.NewBucket[Document](provider, "documents")
-if err != nil {
-    return err
-}
+bucket := sum.NewBucket[Document](provider, "documents")
 
 // Embed in your own type
 type DocumentStore struct {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/zoobz-io/capitan v1.0.2
 	github.com/zoobz-io/cereal v0.1.2
 	github.com/zoobz-io/fig v0.0.3
-	github.com/zoobz-io/grub v0.1.11
+	github.com/zoobz-io/grub v0.1.17
 	github.com/zoobz-io/rocco v0.1.16
 	github.com/zoobz-io/scio v0.0.5
 	github.com/zoobz-io/sentinel v1.0.4
@@ -23,7 +23,7 @@ require (
 	github.com/zoobz-io/check v0.0.5 // indirect
 	github.com/zoobz-io/dbml v1.0.1 // indirect
 	github.com/zoobz-io/edamame v1.0.2 // indirect
-	github.com/zoobz-io/lucene v0.0.2 // indirect
+	github.com/zoobz-io/lucene v0.0.4 // indirect
 	github.com/zoobz-io/openapi v1.0.2 // indirect
 	github.com/zoobz-io/soy v1.0.6 // indirect
 	github.com/zoobz-io/vecna v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,10 @@ github.com/zoobz-io/edamame v1.0.2 h1:HisMAzyHOPW5vrzPmTFNLAJMBCrn+lt1LXFSEazLNR
 github.com/zoobz-io/edamame v1.0.2/go.mod h1:af1PKqjn61ba70CSmqB4gLZkZYz8QPDnQVeRFasiNu4=
 github.com/zoobz-io/fig v0.0.3 h1:6IliqhlJM/LHPROkcHyOFDJAte9uwhg7x9lRPAdeWCs=
 github.com/zoobz-io/fig v0.0.3/go.mod h1:E0LCV07Y3/XpDuO+0vhvYcmNj83ArG3fievsPjDreH4=
-github.com/zoobz-io/grub v0.1.11 h1:SdSpVhOtJKmQf6oBIotnGW9rMWG41rnICs0FXG2iCB0=
-github.com/zoobz-io/grub v0.1.11/go.mod h1:HIMqe8jZbO07OpWf5E2dbc5OKFJcnw308zzUCaX9SkQ=
-github.com/zoobz-io/lucene v0.0.2 h1:O+MFaq/GQ3X2K90t2od1j8TsGranAM8FJisn7y8pDYs=
-github.com/zoobz-io/lucene v0.0.2/go.mod h1:rGPnnt5XV8B4UcRKn/0VrlFM7fMz+tP7+lnKHSWP15o=
+github.com/zoobz-io/grub v0.1.17 h1:/ySXjYCB27uOQDJJIkdo99wU4KuBGjmgcctPw2X3Qk8=
+github.com/zoobz-io/grub v0.1.17/go.mod h1:PIlZjwGAKknT9AMEG6rLSXU5Uxu5Zd5L1qj22IhWU8A=
+github.com/zoobz-io/lucene v0.0.4 h1:hmt8rjzCVGPecVTCIYOiu/QDZioE8NQqUUvm+/FXl4E=
+github.com/zoobz-io/lucene v0.0.4/go.mod h1:rGPnnt5XV8B4UcRKn/0VrlFM7fMz+tP7+lnKHSWP15o=
 github.com/zoobz-io/openapi v1.0.2 h1:KWJmjt/EYTkyzTvNCEK6BXDRWV7J45LhRXqWWZjm2mc=
 github.com/zoobz-io/openapi v1.0.2/go.mod h1:B1AhdYd+dAtRRPIH8IQo2yjrvZbUdQAIhyrC+WhdrZA=
 github.com/zoobz-io/rocco v0.1.16 h1:IMcpUxgFARrTCCqldNDJK70Yg6gBleJN/9ArSqCWOZk=

--- a/testing/integration/data_test.go
+++ b/testing/integration/data_test.go
@@ -63,14 +63,7 @@ func TestDatabaseIntegration(t *testing.T) {
 		sqlxDB.Exec(`DROP TABLE IF EXISTS test_models`)
 	})
 
-	database, err := sum.NewDatabase[testModel](sqlxDB, "test_models", postgres.New())
-	if err != nil {
-		t.Fatalf("NewDatabase failed: %v", err)
-	}
-
-	if database == nil {
-		t.Fatal("expected non-nil database")
-	}
+	database := sum.NewDatabase[testModel](sqlxDB, "test_models", postgres.New())
 
 	if database.Database == nil {
 		t.Error("expected non-nil embedded grub.Database")

--- a/testing/integration/data_test.go
+++ b/testing/integration/data_test.go
@@ -127,14 +127,7 @@ func TestStoreIntegration(t *testing.T) {
 
 	_ = sum.Start()
 
-	store, err := sum.NewStore[testModel](mockStoreProvider{}, "test-store")
-	if err != nil {
-		t.Fatalf("NewStore failed: %v", err)
-	}
-
-	if store == nil {
-		t.Fatal("expected non-nil store")
-	}
+	store := sum.NewStore[testModel](mockStoreProvider{}, "test-store")
 
 	if store.Store == nil {
 		t.Error("expected non-nil embedded grub.Store")
@@ -190,14 +183,7 @@ func TestBucketIntegration(t *testing.T) {
 
 	_ = sum.Start()
 
-	bucket, err := sum.NewBucket[testModel](mockBucketProvider{}, "test-bucket")
-	if err != nil {
-		t.Fatalf("NewBucket failed: %v", err)
-	}
-
-	if bucket == nil {
-		t.Fatal("expected non-nil bucket")
-	}
+	bucket := sum.NewBucket[testModel](mockBucketProvider{}, "test-bucket")
 
 	if bucket.Bucket == nil {
 		t.Error("expected non-nil embedded grub.Bucket")


### PR DESCRIPTION
## Summary

- Makes `NewDatabase[M]` and `NewSearch[M]` infallible, matching the pattern established by `NewBoundary` in v0.0.11
- Upgrades grub `v0.1.11 → v0.1.17` and lucene `v0.0.2 → v0.0.4` (upstream constructors now infallible)
- Catalog registration errors panic as programmer errors (duplicate table/index names)

## Test plan

- [x] All unit tests pass
- [x] Integration tests updated and pass
- [x] `go vet` clean

Closes #12