### PR TITLE
feat: add config batching and type-annotated config errors (#14)

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package sum
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/zoobz-io/fig"
 )
@@ -10,6 +12,7 @@ import (
 // Config loads configuration of type T via fig and registers it with the service locator.
 // Pass nil for provider if secrets are not needed.
 // Retrieve the configuration later with Use[T](ctx).
+// Errors are annotated with the type name for diagnostics.
 func Config[T any](ctx context.Context, k Key, provider fig.SecretProvider) error {
 	var cfg T
 	var opts []fig.SecretProvider
@@ -17,8 +20,24 @@ func Config[T any](ctx context.Context, k Key, provider fig.SecretProvider) erro
 		opts = append(opts, provider)
 	}
 	if err := fig.LoadContext(ctx, &cfg, opts...); err != nil {
-		return err
+		return fmt.Errorf("config %s: %w", reflect.TypeOf(cfg).Name(), err)
 	}
 	Register[T](k, cfg)
+	return nil
+}
+
+// ConfigAll runs configuration loaders sequentially and returns the first error.
+// Each loader is typically a closure wrapping a Config[T] call:
+//
+//	sum.ConfigAll(
+//	    func() error { return sum.Config[DBConfig](ctx, k, nil) },
+//	    func() error { return sum.Config[RedisConfig](ctx, k, secrets) },
+//	)
+func ConfigAll(loaders ...func() error) error {
+	for _, load := range loaders {
+		if err := load(); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ package sum
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -91,3 +92,83 @@ func TestConfigRequiredMissing(t *testing.T) {
 		t.Error("expected error for missing required field")
 	}
 }
+
+func TestConfigErrorIncludesTypeName(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	err := Config[requiredConfig](ctx, k, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); !strings.Contains(got, "requiredConfig") {
+		t.Errorf("expected error to contain type name 'requiredConfig', got: %s", got)
+	}
+}
+
+type secondConfig struct {
+	Value string `env:"TEST_SECOND_VALUE" default:"second"`
+}
+
+func TestConfigAll(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	err := ConfigAll(
+		func() error { return Config[testConfig](ctx, k, nil) },
+		func() error { return Config[secondConfig](ctx, k, nil) },
+	)
+	if err != nil {
+		t.Fatalf("ConfigAll failed: %v", err)
+	}
+
+	cfg, err := Use[testConfig](ctx)
+	if err != nil {
+		t.Fatalf("Use testConfig failed: %v", err)
+	}
+	if cfg.Name != "default-name" {
+		t.Errorf("expected 'default-name', got '%s'", cfg.Name)
+	}
+
+	sec, err := Use[secondConfig](ctx)
+	if err != nil {
+		t.Fatalf("Use secondConfig failed: %v", err)
+	}
+	if sec.Value != "second" {
+		t.Errorf("expected 'second', got '%s'", sec.Value)
+	}
+}
+
+func TestConfigAllStopsOnFirstError(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	called := false
+	err := ConfigAll(
+		func() error { return Config[requiredConfig](ctx, k, nil) },
+		func() error { called = true; return Config[testConfig](ctx, k, nil) },
+	)
+	if err == nil {
+		t.Fatal("expected error from first loader")
+	}
+	if called {
+		t.Error("second loader should not have been called")
+	}
+}
+
+func TestConfigAllEmpty(t *testing.T) {
+	err := ConfigAll()
+	if err != nil {
+		t.Errorf("expected nil error for empty ConfigAll, got: %v", err)
+	}
+}
+


### PR DESCRIPTION
## Summary
- `Config[T]` errors now include the type name for diagnostics (e.g. `config DBConfig: ...`)
- New `ConfigAll` helper runs config loaders sequentially, stops on first error

Part 1 of #14 — application bootstrap ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)