### PR TITLE
feat: config batching and type-annotated errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package sum
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/zoobz-io/fig"
 )
@@ -10,6 +12,7 @@ import (
 // Config loads configuration of type T via fig and registers it with the service locator.
 // Pass nil for provider if secrets are not needed.
 // Retrieve the configuration later with Use[T](ctx).
+// Errors are annotated with the type name for diagnostics.
 func Config[T any](ctx context.Context, k Key, provider fig.SecretProvider) error {
 	var cfg T
 	var opts []fig.SecretProvider
@@ -17,8 +20,24 @@ func Config[T any](ctx context.Context, k Key, provider fig.SecretProvider) erro
 		opts = append(opts, provider)
 	}
 	if err := fig.LoadContext(ctx, &cfg, opts...); err != nil {
-		return err
+		return fmt.Errorf("config %s: %w", reflect.TypeOf(cfg).Name(), err)
 	}
 	Register[T](k, cfg)
+	return nil
+}
+
+// ConfigAll runs configuration loaders sequentially and returns the first error.
+// Each loader is typically a closure wrapping a Config[T] call:
+//
+//	sum.ConfigAll(
+//	    func() error { return sum.Config[DBConfig](ctx, k, nil) },
+//	    func() error { return sum.Config[RedisConfig](ctx, k, secrets) },
+//	)
+func ConfigAll(loaders ...func() error) error {
+	for _, load := range loaders {
+		if err := load(); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -4,9 +4,9 @@ package sum
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/zoobz-io/fig"
+	"github.com/zoobz-io/sentinel"
 )
 
 // Config loads configuration of type T via fig and registers it with the service locator.
@@ -14,13 +14,14 @@ import (
 // Retrieve the configuration later with Use[T](ctx).
 // Errors are annotated with the type name for diagnostics.
 func Config[T any](ctx context.Context, k Key, provider fig.SecretProvider) error {
+	meta := sentinel.Inspect[T]()
 	var cfg T
 	var opts []fig.SecretProvider
 	if provider != nil {
 		opts = append(opts, provider)
 	}
 	if err := fig.LoadContext(ctx, &cfg, opts...); err != nil {
-		return fmt.Errorf("config %s: %w", reflect.TypeOf(cfg).Name(), err)
+		return fmt.Errorf("config %s: %w", meta.FQDN, err)
 	}
 	Register[T](k, cfg)
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ package sum
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -91,3 +92,83 @@ func TestConfigRequiredMissing(t *testing.T) {
 		t.Error("expected error for missing required field")
 	}
 }
+
+func TestConfigErrorIncludesTypeName(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	err := Config[requiredConfig](ctx, k, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); !strings.Contains(got, "requiredConfig") {
+		t.Errorf("expected error to contain type name 'requiredConfig', got: %s", got)
+	}
+}
+
+type secondConfig struct {
+	Value string `env:"TEST_SECOND_VALUE" default:"second"`
+}
+
+func TestConfigAll(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	err := ConfigAll(
+		func() error { return Config[testConfig](ctx, k, nil) },
+		func() error { return Config[secondConfig](ctx, k, nil) },
+	)
+	if err != nil {
+		t.Fatalf("ConfigAll failed: %v", err)
+	}
+
+	cfg, err := Use[testConfig](ctx)
+	if err != nil {
+		t.Fatalf("Use testConfig failed: %v", err)
+	}
+	if cfg.Name != "default-name" {
+		t.Errorf("expected 'default-name', got '%s'", cfg.Name)
+	}
+
+	sec, err := Use[secondConfig](ctx)
+	if err != nil {
+		t.Fatalf("Use secondConfig failed: %v", err)
+	}
+	if sec.Value != "second" {
+		t.Errorf("expected 'second', got '%s'", sec.Value)
+	}
+}
+
+func TestConfigAllStopsOnFirstError(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	k := Start()
+	ctx := context.Background()
+
+	called := false
+	err := ConfigAll(
+		func() error { return Config[requiredConfig](ctx, k, nil) },
+		func() error { called = true; return Config[testConfig](ctx, k, nil) },
+	)
+	if err == nil {
+		t.Fatal("expected error from first loader")
+	}
+	if called {
+		t.Error("second loader should not have been called")
+	}
+}
+
+func TestConfigAllEmpty(t *testing.T) {
+	err := ConfigAll()
+	if err != nil {
+		t.Errorf("expected nil error for empty ConfigAll, got: %v", err)
+	}
+}
+


### PR DESCRIPTION
## Summary

- `Config[T]` now annotates errors with the type name via `reflect.TypeOf`, eliminating per-call `fmt.Errorf` wrapping in application bootstrap
- Added `ConfigAll(loaders ...func() error) error` — runs config loaders sequentially, stops on first error

Part 1 of #14 — config batching.

## Test plan

- [x] Existing Config tests pass unchanged
- [x] Error includes type name (`requiredConfig`)
- [x] ConfigAll loads multiple configs and registers all with slush
- [x] ConfigAll stops on first error (second loader not called)
- [x] ConfigAll with no loaders returns nil
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)