### PR TITLE
feat: infrastructure connectors with lifecycle management

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"reflect"
 
 	"github.com/zoobz-io/capitan"
 	"github.com/zoobz-io/sentinel"
@@ -40,7 +39,7 @@ func Connect[T any](ctx context.Context, k Key, name string, factory func(contex
 		return fmt.Errorf("connect %s: %w", name, err)
 	}
 	Register[T](k, client)
-	typeName := reflect.TypeOf(client).String()
+	typeName := name
 	if meta, err := sentinel.TryInspect[T](); err == nil {
 		typeName = meta.FQDN
 	}

--- a/connector.go
+++ b/connector.go
@@ -1,0 +1,54 @@
+package sum
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/zoobz-io/capitan"
+)
+
+// Signals emitted during infrastructure lifecycle.
+var (
+	SignalConnected    = capitan.NewSignal("sum.connected", "Infrastructure client connected")
+	SignalDisconnected = capitan.NewSignal("sum.disconnected", "Infrastructure client disconnected")
+)
+
+// Field keys for connector signals.
+var (
+	KeyConnectorName  = capitan.NewStringKey("connector")
+	KeyConnectorType  = capitan.NewStringKey("type")
+	KeyConnectorError = capitan.NewErrorKey("error")
+)
+
+// namedCloser pairs a name with an io.Closer for ordered shutdown.
+type namedCloser struct {
+	name   string
+	closer io.Closer
+}
+
+// Connect creates an infrastructure client via factory, registers it with slush,
+// emits a connected signal, and tracks io.Closer instances for automatic shutdown.
+// The name identifies this connection in signals and shutdown logs.
+// If the client implements io.Closer, it will be closed during Service.Shutdown
+// in reverse connection order.
+func Connect[T any](ctx context.Context, k Key, name string, factory func(context.Context) (T, error)) error {
+	client, err := factory(ctx)
+	if err != nil {
+		return fmt.Errorf("connect %s: %w", name, err)
+	}
+	Register[T](k, client)
+	capitan.Info(ctx, SignalConnected,
+		KeyConnectorName.Field(name),
+		KeyConnectorType.Field(reflect.TypeOf(client).String()),
+	)
+
+	if closer, ok := any(client).(io.Closer); ok {
+		s := svc()
+		s.mu.Lock()
+		s.closers = append(s.closers, namedCloser{name: name, closer: closer})
+		s.mu.Unlock()
+	}
+	return nil
+}

--- a/connector.go
+++ b/connector.go
@@ -24,8 +24,8 @@ var (
 
 // namedCloser pairs a name with an io.Closer for ordered shutdown.
 type namedCloser struct {
-	name   string
 	closer io.Closer
+	name   string
 }
 
 // Connect creates an infrastructure client via factory, registers it with slush,
@@ -51,7 +51,7 @@ func Connect[T any](ctx context.Context, k Key, name string, factory func(contex
 	if closer, ok := any(client).(io.Closer); ok {
 		s := svc()
 		s.mu.Lock()
-		s.closers = append(s.closers, namedCloser{name: name, closer: closer})
+		s.closers = append(s.closers, namedCloser{closer: closer, name: name})
 		s.mu.Unlock()
 	}
 	return nil

--- a/connector.go
+++ b/connector.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/zoobz-io/capitan"
+	"github.com/zoobz-io/sentinel"
 )
 
 // Signals emitted during infrastructure lifecycle.
@@ -39,9 +40,13 @@ func Connect[T any](ctx context.Context, k Key, name string, factory func(contex
 		return fmt.Errorf("connect %s: %w", name, err)
 	}
 	Register[T](k, client)
+	typeName := reflect.TypeOf(client).String()
+	if meta, err := sentinel.TryInspect[T](); err == nil {
+		typeName = meta.FQDN
+	}
 	capitan.Info(ctx, SignalConnected,
 		KeyConnectorName.Field(name),
-		KeyConnectorType.Field(reflect.TypeOf(client).String()),
+		KeyConnectorType.Field(typeName),
 	)
 
 	if closer, ok := any(client).(io.Closer); ok {

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,221 @@
+//go:build testing
+
+package sum
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zoobz-io/capitan"
+)
+
+type mockClient struct {
+	closed atomic.Bool
+}
+
+func (m *mockClient) Close() error {
+	m.closed.Store(true)
+	return nil
+}
+
+type mockClientNoCloser struct {
+	value string
+}
+
+func TestConnect(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	New()
+	k := Start()
+	ctx := context.Background()
+
+	client := &mockClient{}
+	err := Connect[*mockClient](ctx, k, "test-db", func(ctx context.Context) (*mockClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	got, err := Use[*mockClient](ctx)
+	if err != nil {
+		t.Fatalf("Use failed: %v", err)
+	}
+	if got != client {
+		t.Error("expected same client instance from registry")
+	}
+}
+
+func TestConnectFactoryError(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	New()
+	k := Start()
+	ctx := context.Background()
+
+	err := Connect[*mockClient](ctx, k, "bad-db", func(ctx context.Context) (*mockClient, error) {
+		return nil, errors.New("connection refused")
+	})
+	if err == nil {
+		t.Fatal("expected error from factory")
+	}
+	if got := err.Error(); got != "connect bad-db: connection refused" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestConnectTracksCloser(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	s := New()
+	k := Start()
+	ctx := context.Background()
+
+	err := Connect[*mockClient](ctx, k, "closeable", func(ctx context.Context) (*mockClient, error) {
+		return &mockClient{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	s.mu.RLock()
+	n := len(s.closers)
+	s.mu.RUnlock()
+	if n != 1 {
+		t.Errorf("expected 1 closer, got %d", n)
+	}
+}
+
+func TestConnectNoCloserNotTracked(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	s := New()
+	k := Start()
+	ctx := context.Background()
+
+	err := Connect[*mockClientNoCloser](ctx, k, "no-closer", func(ctx context.Context) (*mockClientNoCloser, error) {
+		return &mockClientNoCloser{value: "test"}, nil
+	})
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	s.mu.RLock()
+	n := len(s.closers)
+	s.mu.RUnlock()
+	if n != 0 {
+		t.Errorf("expected 0 closers, got %d", n)
+	}
+}
+
+func TestConnectEmitsSignal(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	New()
+	k := Start()
+	ctx := context.Background()
+
+	var received bool
+	listener := capitan.Hook(SignalConnected, func(ctx context.Context, ev *capitan.Event) {
+		name, ok := KeyConnectorName.From(ev)
+		if ok && name == "signal-test" {
+			received = true
+		}
+	})
+	defer listener.Close()
+
+	err := Connect[*mockClient](ctx, k, "signal-test", func(ctx context.Context) (*mockClient, error) {
+		return &mockClient{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	if !received {
+		t.Error("expected SignalConnected to be emitted")
+	}
+}
+
+func TestShutdownClosesInReverseOrder(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	s := New()
+	k := Start()
+	ctx := context.Background()
+
+	first := &mockClient{}
+	Connect[*mockClient](ctx, k, "first", func(ctx context.Context) (*mockClient, error) {
+		return first, nil
+	})
+
+	second := &mockClient{}
+	third := &mockClient{}
+	s.mu.Lock()
+	s.closers = append(s.closers,
+		namedCloser{name: "second", closer: second},
+		namedCloser{name: "third", closer: third},
+	)
+	s.mu.Unlock()
+
+	var closeOrder []string
+	listener := capitan.Hook(SignalDisconnected, func(ctx context.Context, ev *capitan.Event) {
+		if name, ok := KeyConnectorName.From(ev); ok {
+			closeOrder = append(closeOrder, name)
+		}
+	})
+	defer listener.Close()
+
+	// Start and shutdown after server is ready
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start("127.0.0.1", 0)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	if len(closeOrder) != 3 {
+		t.Fatalf("expected 3 disconnects, got %d: %v", len(closeOrder), closeOrder)
+	}
+	if closeOrder[0] != "third" || closeOrder[1] != "second" || closeOrder[2] != "first" {
+		t.Errorf("expected reverse order [third second first], got %v", closeOrder)
+	}
+
+	if !first.closed.Load() || !second.closed.Load() || !third.closed.Load() {
+		t.Error("expected all clients to be closed")
+	}
+}
+
+func TestShutdownNoClosers(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	s := New()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start("127.0.0.1", 0)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil && err.Error() != "http: Server closed" {
+			t.Errorf("unexpected start error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("timeout waiting for server to stop")
+	}
+}

--- a/reset.go
+++ b/reset.go
@@ -18,6 +18,7 @@ func Reset() {
 		instance.encryptors = make(map[EncryptAlgo]Encryptor)
 		instance.hashers = make(map[HashAlgo]Hasher)
 		instance.maskers = make(map[MaskType]Masker)
+		instance.closers = nil
 		instance.codec = nil
 		instance.mu.Unlock()
 	}

--- a/service.go
+++ b/service.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/zoobz-io/capitan"
 	"github.com/zoobz-io/cereal"
 	"github.com/zoobz-io/rocco"
 	"github.com/zoobz-io/scio"
@@ -25,6 +26,7 @@ type Service struct {
 	encryptors map[cereal.EncryptAlgo]cereal.Encryptor
 	hashers    map[cereal.HashAlgo]cereal.Hasher
 	maskers    map[cereal.MaskType]cereal.Masker
+	closers    []namedCloser
 	engine     *rocco.Engine
 	catalog    *scio.Scio
 	codec      cereal.Codec
@@ -113,11 +115,36 @@ func (s *Service) Start(host string, port int) error {
 }
 
 // Shutdown gracefully stops the service.
+// Closes infrastructure connections in reverse order before stopping the engine.
 func (s *Service) Shutdown(ctx context.Context) error {
 	if s.engine == nil {
 		return fmt.Errorf("service not started")
 	}
-	return s.engine.Shutdown(ctx)
+
+	// Shutdown engine first to stop accepting requests.
+	err := s.engine.Shutdown(ctx)
+
+	// Close infrastructure in reverse connection order.
+	s.mu.RLock()
+	closers := make([]namedCloser, len(s.closers))
+	copy(closers, s.closers)
+	s.mu.RUnlock()
+
+	for i := len(closers) - 1; i >= 0; i-- {
+		c := closers[i]
+		if cerr := c.closer.Close(); cerr != nil {
+			capitan.Error(ctx, SignalDisconnected,
+				KeyConnectorName.Field(c.name),
+				KeyConnectorError.Field(cerr),
+			)
+		} else {
+			capitan.Info(ctx, SignalDisconnected,
+				KeyConnectorName.Field(c.name),
+			)
+		}
+	}
+
+	return err
 }
 
 // Run starts the service and blocks until a shutdown signal is received.

--- a/service.go
+++ b/service.go
@@ -26,10 +26,10 @@ type Service struct {
 	encryptors map[cereal.EncryptAlgo]cereal.Encryptor
 	hashers    map[cereal.HashAlgo]cereal.Hasher
 	maskers    map[cereal.MaskType]cereal.Masker
-	closers    []namedCloser
 	engine     *rocco.Engine
 	catalog    *scio.Scio
 	codec      cereal.Codec
+	closers    []namedCloser
 	mu         sync.RWMutex
 }
 


### PR DESCRIPTION
## Summary

- Added `Connect[T]` — creates infrastructure clients via factory, registers with slush, emits capitan signals, tracks `io.Closer` for shutdown
- Service.Shutdown now closes infrastructure in reverse connection order with signal emission
- New signals: `SignalConnected`, `SignalDisconnected` with `KeyConnectorName`, `KeyConnectorType`, `KeyConnectorError` field keys

Part 2 of #14 — infrastructure connectors.

## Test plan

- [x] Connect registers client with slush, retrievable via Use
- [x] Factory errors wrapped with connector name
- [x] io.Closer clients tracked, non-Closer clients skipped
- [x] SignalConnected emitted on successful connect
- [x] Shutdown closes in reverse connection order with SignalDisconnected
- [x] Shutdown with no closers works cleanly
- [x] Full test suite passes (unit + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)